### PR TITLE
Implemented locale agnostic fix for atlas element bounds display

### DIFF
--- a/KleiStudio.sln
+++ b/KleiStudio.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31702.278
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KleiLib", "src\KleiLib\KleiLib.csproj", "{E617373D-4BEE-41ED-8DEE-F7AC6B6A96EC}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "lib", "lib", "{B1936C2D-59DD-4D33-99CC-BC6AD598CC9A}"
@@ -37,8 +39,10 @@ Global
 		{E617373D-4BEE-41ED-8DEE-F7AC6B6A96EC}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{E617373D-4BEE-41ED-8DEE-F7AC6B6A96EC}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{E617373D-4BEE-41ED-8DEE-F7AC6B6A96EC}.Release|Win32.ActiveCfg = Release|Any CPU
-		{E617373D-4BEE-41ED-8DEE-F7AC6B6A96EC}.Release|x64.ActiveCfg = Release|Any CPU
-		{E617373D-4BEE-41ED-8DEE-F7AC6B6A96EC}.Release|x86.ActiveCfg = Release|Any CPU
+		{E617373D-4BEE-41ED-8DEE-F7AC6B6A96EC}.Release|x64.ActiveCfg = Release|x64
+		{E617373D-4BEE-41ED-8DEE-F7AC6B6A96EC}.Release|x64.Build.0 = Release|x64
+		{E617373D-4BEE-41ED-8DEE-F7AC6B6A96EC}.Release|x86.ActiveCfg = Release|x86
+		{E617373D-4BEE-41ED-8DEE-F7AC6B6A96EC}.Release|x86.Build.0 = Release|x86
 		{47282830-B66F-4A8F-B366-ADF0E4B49E45}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{47282830-B66F-4A8F-B366-ADF0E4B49E45}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
 		{47282830-B66F-4A8F-B366-ADF0E4B49E45}.Debug|Mixed Platforms.Build.0 = Debug|x86
@@ -50,7 +54,8 @@ Global
 		{47282830-B66F-4A8F-B366-ADF0E4B49E45}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{47282830-B66F-4A8F-B366-ADF0E4B49E45}.Release|Mixed Platforms.Build.0 = Release|x86
 		{47282830-B66F-4A8F-B366-ADF0E4B49E45}.Release|Win32.ActiveCfg = Release|x86
-		{47282830-B66F-4A8F-B366-ADF0E4B49E45}.Release|x64.ActiveCfg = Release|x86
+		{47282830-B66F-4A8F-B366-ADF0E4B49E45}.Release|x64.ActiveCfg = Release|x64
+		{47282830-B66F-4A8F-B366-ADF0E4B49E45}.Release|x64.Build.0 = Release|x64
 		{47282830-B66F-4A8F-B366-ADF0E4B49E45}.Release|x86.ActiveCfg = Release|x86
 		{47282830-B66F-4A8F-B366-ADF0E4B49E45}.Release|x86.Build.0 = Release|x86
 		{DB2992FF-1AAF-447A-BD06-6C4D4FB7F7B0}.Debug|Any CPU.ActiveCfg = Debug|x86
@@ -64,7 +69,8 @@ Global
 		{DB2992FF-1AAF-447A-BD06-6C4D4FB7F7B0}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{DB2992FF-1AAF-447A-BD06-6C4D4FB7F7B0}.Release|Mixed Platforms.Build.0 = Release|x86
 		{DB2992FF-1AAF-447A-BD06-6C4D4FB7F7B0}.Release|Win32.ActiveCfg = Release|x86
-		{DB2992FF-1AAF-447A-BD06-6C4D4FB7F7B0}.Release|x64.ActiveCfg = Release|x86
+		{DB2992FF-1AAF-447A-BD06-6C4D4FB7F7B0}.Release|x64.ActiveCfg = Release|x64
+		{DB2992FF-1AAF-447A-BD06-6C4D4FB7F7B0}.Release|x64.Build.0 = Release|x64
 		{DB2992FF-1AAF-447A-BD06-6C4D4FB7F7B0}.Release|x86.ActiveCfg = Release|x86
 		{DB2992FF-1AAF-447A-BD06-6C4D4FB7F7B0}.Release|x86.Build.0 = Release|x86
 		{465D1429-5C4E-4AE9-97FD-1AC7B4E9818C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -82,9 +88,13 @@ Global
 		{465D1429-5C4E-4AE9-97FD-1AC7B4E9818C}.Release|Win32.ActiveCfg = Release|x64
 		{465D1429-5C4E-4AE9-97FD-1AC7B4E9818C}.Release|x64.ActiveCfg = Release|x64
 		{465D1429-5C4E-4AE9-97FD-1AC7B4E9818C}.Release|x64.Build.0 = Release|x64
-		{465D1429-5C4E-4AE9-97FD-1AC7B4E9818C}.Release|x86.ActiveCfg = Release|x64
+		{465D1429-5C4E-4AE9-97FD-1AC7B4E9818C}.Release|x86.ActiveCfg = Release|x86
+		{465D1429-5C4E-4AE9-97FD-1AC7B4E9818C}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E4848D7C-8762-4720-901C-E8D5976AB4E7}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This version of Klei Studio is a fork of zxcvbnm3057's fork of the original. The
 This fork extends that further with the following changes:
  - The fix that zxcvbnm3057 implemented for not being able to select individual elements in an atlas within TEXTool in locals that use decimal points as the fractional delimiter inadvertently broke the feature for user's in locales that use commas as the fractional delimiter. This version implements a locale agnostic fix.
  - Since the original this tool has had an off-by-one issue when reading/writing a TEX file's texture type (1D, 2D, 3D or cube-mapped) and so it displayed the wrong type when reading a file and one had to select the option proceeding their actual selection (i.d. "1D" to create a 2D texture) when making a TEX file in TEXCreator; this also made creating true 1D textures impossible. This version fixes this problem.
+ - TEXCreator will now actually set the true pitch value of mipmaps instead of just using 0. While TEXTool didn't rely on this value and just assumed the default pitch of image_width * 4, any tool that reads and uses the explicit pitch value instead of assuming the default would break since it was set to 0.
 
 ## Synopsis
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 This version of Klei Studio is a fork of zxcvbnm3057's fork of the original. Their fork implements some nice quality-of-life improvements and fixes to the original that you can read about in its [history](https://github.com/zxcvbnm3057/dont-starve-tools/commits/master).
 
 This fork extends that further with the following changes:
- - The fix that zxcvbnm3057 implemented for not being able to select individual elements in an atlas within TEXTool in locals that use decimal points as the fractional delimiter inadvertently broke the feature for user's in locales that use commas as the fractional delimiter. This version implements a locale agnostic fix.
- - Since the original this tool has had an off-by-one issue when reading/writing a TEX file's texture type (1D, 2D, 3D or cube-mapped) and so it displayed the wrong type when reading a file and one had to select the option proceeding their actual selection (i.d. "1D" to create a 2D texture) when making a TEX file in TEXCreator; this also made creating true 1D textures impossible. This version fixes this problem.
+ - The fix that zxcvbnm3057 implemented for not being able to select individual elements in an atlas within TEXTool in locales that use decimal points as the fractional delimiter inadvertently broke the feature for user's in locales that use commas as the fractional delimiter. This version implements a locale agnostic fix.
+ - Since the original this tool has had an off-by-one issue when reading/writing a TEX file's texture type (1D, 2D, 3D or cube-mapped) and so it displayed the wrong type when reading a file and one had to select the option proceeding their actual selection (i.e. "1D" to create a 2D texture) when making a TEX file in TEXCreator; this also made creating true 1D textures impossible. This version fixes this problem.
  - TEXCreator will now actually set the true pitch value of mipmaps instead of just using 0. While TEXTool didn't rely on this value and just assumed the default pitch of image_width * 4, any tool that reads and uses the explicit pitch value instead of assuming the default would break since it was set to 0.
 
 ## Synopsis

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-[![](https://img.shields.io/github/stars/handsomematt/dont-starve-tools.svg?style=social&label=Star)]()
-[![](https://img.shields.io/github/release/handsomematt/dont-starve-tools.svg)]()
-[![](https://img.shields.io/github/license/handsomematt/dont-starve-tools.svg)]()
+## A Fork of a Fork
+This version of Klei Studio is a fork of zxcvbnm3057's fork of the original. Their fork implements some nice quality-of-life improvements and fixes to the original that you can read about in its [history](https://github.com/zxcvbnm3057/dont-starve-tools/commits/master).
+
+This fork extends that further with the following changes:
+ - The fix that zxcvbnm3057 implemented for not being able to select individual elements in an atlas within TEXTool in locals that use decimal points as the fractional delimiter inadvertently broke the feature for user's in locales that use commas as the fractional delimiter. This version implements a locale agnostic fix.
+ - Since the original this tool has had an off-by-one issue when reading/writing a TEX file's texture type (1D, 2D, 3D or cube-mapped) and so it displayed the wrong type when reading a file and one had to select the option proceeding their actual selection (i.d. "1D" to create a 2D texture) when making a TEX file in TEXCreator; this also made creating true 1D textures impossible. This version fixes this problem.
 
 ## Synopsis
 
@@ -10,7 +13,7 @@ Note: These tools are old and unmaintained and may contain bugs. You should real
 
 ## Quick start
 
-* [Download the latest release](https://github.com/zxcvbnm3057/dont-starve-tools/releases).
+* [Download the latest release](https://github.com/oblivioncth/dont-starve-tools/releases).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ This version of Klei Studio is a fork of zxcvbnm3057's fork of the original. The
 
 This fork extends that further with the following changes:
  - The fix that zxcvbnm3057 implemented for not being able to select individual elements in an atlas within TEXTool in locales that use decimal points as the fractional delimiter inadvertently broke the feature for user's in locales that use commas as the fractional delimiter. This version implements a locale agnostic fix.
- - Since the original this tool has had an off-by-one issue when reading/writing a TEX file's texture type (1D, 2D, 3D or cube-mapped) and so it displayed the wrong type when reading a file and one had to select the option proceeding their actual selection (i.e. "1D" to create a 2D texture) when making a TEX file in TEXCreator; this also made creating true 1D textures impossible. This version fixes this problem.
+ - Since the original, this tool has had an off-by-one issue when reading/writing a TEX file's texture type (1D, 2D, 3D or cube-mapped), and so it displayed the wrong type when reading a file and one had to select the option proceeding their actual selection (i.e. "1D" to create a 2D texture) when making a TEX file in TEXCreator; this also made creating true 1D textures impossible. This version fixes this problem.
  - TEXCreator will now actually set the true pitch value of mipmaps instead of just using 0. While TEXTool didn't rely on this value and just assumed the default pitch of image_width * 4, any tool that reads and uses the explicit pitch value instead of assuming the default would break since it was set to 0.
+ - Fixes an off-by-one error when displaying atlas element dimensions that's been present since the original.
 
 ## Synopsis
 

--- a/src/KleiLib/KleiLib.csproj
+++ b/src/KleiLib/KleiLib.csproj
@@ -32,6 +32,42 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/KleiLib/TEXFile.cs
+++ b/src/KleiLib/TEXFile.cs
@@ -54,13 +54,13 @@ namespace KleiLib
         public enum TextureType : uint
         {
             [Description("1D")]
-            OneD = 1,
+            OneD = 0,
             [Description("2D")]
-            TwoD = 2,
+            TwoD = 1,
             [Description("3D")]
-            ThreeD = 3,
+            ThreeD = 2,
             [Description("Cube Mapped")]
-            Cubemap = 4
+            Cubemap = 3
         };
 
         public readonly char[] KTEXHeader = new char[] { 'K', 'T', 'E', 'X' };

--- a/src/KleiLib/Util.cs
+++ b/src/KleiLib/Util.cs
@@ -25,10 +25,13 @@ SOFTWARE.
 */
 #endregion License
 
+using System.Globalization;
+
 namespace KleiLib
 {
     public static class Util
     {
-
+        // Game formats use US number formatting so that is forced regardless of host region
+        public static readonly CultureInfo GAME_LOCALE = new CultureInfo("en-US");
     }
 }

--- a/src/SquishNET/SquishNET.csproj
+++ b/src/SquishNET/SquishNET.csproj
@@ -78,6 +78,29 @@
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="NativeSquish_x64">
       <HintPath>..\..\lib\NativeSquish_x64.dll</HintPath>

--- a/src/TEXConverter/MainForm.cs
+++ b/src/TEXConverter/MainForm.cs
@@ -155,27 +155,32 @@ namespace TEXCreator
                 }
 
             byte[] finalImageData = null;
+            int pitch = 0;
 
             switch (pixelFormat)
             {
                 case TEXFile.PixelFormat.DXT1:
                     finalImageData = Squish.CompressImage(rgba, inputImage.Width, inputImage.Height, SquishFlags.Dxt1);
+                    pitch = Squish.GetStorageRequirements(inputImage.Width, 1, SquishFlags.Dxt1);
                     break;
                 case TEXFile.PixelFormat.DXT3:
                     finalImageData = Squish.CompressImage(rgba, inputImage.Width, inputImage.Height, SquishFlags.Dxt3);
+                    pitch = Squish.GetStorageRequirements(inputImage.Width, 1, SquishFlags.Dxt3);
                     break;
                 case TEXFile.PixelFormat.DXT5:
                     finalImageData = Squish.CompressImage(rgba, inputImage.Width, inputImage.Height, SquishFlags.Dxt5);
+                    pitch = Squish.GetStorageRequirements(inputImage.Width, 1, SquishFlags.Dxt5);
                     break;
                 case TEXFile.PixelFormat.ARGB:
                     finalImageData = rgba;
+                    pitch = inputImage.Width * 4;
                     break;
             }
 
             var mipmap = new Mipmap();
             mipmap.Width = (ushort)inputImage.Width;
             mipmap.Height = (ushort)inputImage.Height;
-            mipmap.Pitch = 0;
+            mipmap.Pitch = (ushort)pitch;
             mipmap.ARGBData = finalImageData;
 
             return mipmap;

--- a/src/TEXConverter/MainForm.cs
+++ b/src/TEXConverter/MainForm.cs
@@ -249,7 +249,7 @@ namespace TEXCreator
 
             foreach (TEXFile.TextureType textype in Enum.GetValues(typeof(TEXFile.TextureType)))
                 textureTypeComboBox.Items.Add(EnumHelper<TEXFile.TextureType>.GetEnumDescription(textype.ToString()));
-            textureTypeComboBox.Text = EnumHelper<TEXFile.TextureType>.GetEnumDescription(TEXFile.TextureType.OneD.ToString());
+            textureTypeComboBox.Text = EnumHelper<TEXFile.TextureType>.GetEnumDescription(TEXFile.TextureType.TwoD.ToString());
 
             foreach (InterpolationMode mode in Enum.GetValues(typeof(InterpolationMode)))
                 if (mode != InterpolationMode.Invalid)

--- a/src/TEXConverter/Properties/AssemblyInfo.cs
+++ b/src/TEXConverter/Properties/AssemblyInfo.cs
@@ -58,5 +58,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyVersion("1.4.2.1")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/TEXConverter/Properties/AssemblyInfo.cs
+++ b/src/TEXConverter/Properties/AssemblyInfo.cs
@@ -58,5 +58,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.2.1")]
+[assembly: AssemblyVersion("1.4.2.2")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/TEXConverter/Properties/AssemblyInfo.cs
+++ b/src/TEXConverter/Properties/AssemblyInfo.cs
@@ -58,5 +58,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.2.2")]
+[assembly: AssemblyVersion("1.4.2.3")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/TEXConverter/TEXCreator.csproj
+++ b/src/TEXConverter/TEXCreator.csproj
@@ -39,6 +39,24 @@
   <PropertyGroup>
     <ApplicationIcon>icon.ico</ApplicationIcon>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/TEXTool/MainForm.cs
+++ b/src/TEXTool/MainForm.cs
@@ -270,8 +270,8 @@ namespace TEXTool
                 y = element.ImgVmax;
             }
 
-            width = element.ImgHmax - element.ImgHmin;
-            height = Math.Abs(element.ImgVmax - element.ImgVmin);
+            width = element.ImgHmax - element.ImgHmin + 1;
+            height = Math.Abs(element.ImgVmax - element.ImgVmin) + 1;
 
             graphicsPath = new GraphicsPath();
             graphicsPath.AddRectangle(new Rectangle(x, y, width, height));

--- a/src/TEXTool/Properties/AssemblyInfo.cs
+++ b/src/TEXTool/Properties/AssemblyInfo.cs
@@ -39,5 +39,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("76bbf4d2-c278-4dae-a48c-18f660bc6e61")]
 
-[assembly: AssemblyVersion("1.4.2.0")]
+[assembly: AssemblyVersion("1.4.2.1")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/TEXTool/Properties/AssemblyInfo.cs
+++ b/src/TEXTool/Properties/AssemblyInfo.cs
@@ -39,5 +39,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("76bbf4d2-c278-4dae-a48c-18f660bc6e61")]
 
-[assembly: AssemblyVersion("1.4.2.1")]
+[assembly: AssemblyVersion("1.4.2.2")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/TEXTool/Properties/AssemblyInfo.cs
+++ b/src/TEXTool/Properties/AssemblyInfo.cs
@@ -39,5 +39,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("76bbf4d2-c278-4dae-a48c-18f660bc6e61")]
 
-[assembly: AssemblyVersion("1.4.2.2")]
+[assembly: AssemblyVersion("1.4.2.3")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/TEXTool/TEXTool.cs
+++ b/src/TEXTool/TEXTool.cs
@@ -231,8 +231,8 @@ namespace TEXTool
                 foreach (XmlNode xChild in xNodeElements.ChildNodes)
                 {
                     string name = xChild.Attributes.GetNamedItem("name").Value;
-                    double u1 = Convert.ToDouble(xChild.Attributes.GetNamedItem("u1").Value);
-                    double u2 = Convert.ToDouble(xChild.Attributes.GetNamedItem("u2").Value);
+                    double u1 = Convert.ToDouble(xChild.Attributes.GetNamedItem("u1").Value, Util.GAME_LOCALE);
+                    double u2 = Convert.ToDouble(xChild.Attributes.GetNamedItem("u2").Value, Util.GAME_LOCALE);
 
                     /* !!! IMPORTANT TIP !!!
                      * You may need to invert the y-axis depending on the software you use to check your pixel coordinates. 
@@ -245,8 +245,8 @@ namespace TEXTool
                      */
 
                     /* NORMAL THE Y-AXIS */
-                    double v1 = Convert.ToDouble(xChild.Attributes.GetNamedItem("v1").Value);
-                    double v2 = Convert.ToDouble(xChild.Attributes.GetNamedItem("v2").Value);
+                    double v1 = Convert.ToDouble(xChild.Attributes.GetNamedItem("v1").Value, Util.GAME_LOCALE);
+                    double v2 = Convert.ToDouble(xChild.Attributes.GetNamedItem("v2").Value, Util.GAME_LOCALE);
 
                     /* INVERT THE Y-AXIS */
                     v1 = 1 - v1;

--- a/src/TEXTool/TEXTool.csproj
+++ b/src/TEXTool/TEXTool.csproj
@@ -55,6 +55,25 @@
   <PropertyGroup>
     <StartupObject />
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Cyotek.Windows.Forms.ImageBox">
       <HintPath>..\..\lib\Cyotek.Windows.Forms.ImageBox.dll</HintPath>


### PR DESCRIPTION
I cloned the original repo to look into the Atlas parse bug myself, fixed it, and then when I went to make a fork I skimmed through the existing ones and found yours.

Nice QoL changes and fixes to the original, definitely nice improvements to have.

I just wanted contribute an improvement to the Atlas fix that I had used in my copy since your fork makes maintaining my own unnecessary. 

In short, it's evident from the original source that Matt resided in a European local and hard coded the Atlas interpretation for that region's number formatting. Your original fix essentially did the opposite and hard coded the function to work for the US number formatting system, while this change allows it to function correctly for both.

See the commit message for details.